### PR TITLE
Update HttpUrlProcessingTask.java

### DIFF
--- a/src/main/java/com/dell/jobot/HttpUrlProcessingTask.java
+++ b/src/main/java/com/dell/jobot/HttpUrlProcessingTask.java
@@ -52,6 +52,10 @@ implements Runnable {
 			e.printStackTrace(System.err);
 		}
 		conn.setRequestProperty("User-Agent", "jobot");
+		//Alfred
+		conn.setConnectTimeout(5*1000);
+		conn.setReadTimeout(15*1000);
+ 		conn.setRequestProperty("Connection", "keep-alive");
 	}
 
 	void handleResponse(final HttpURLConnection conn) {


### PR DESCRIPTION
Настройка объекта класса HttpURLConnection, путем задания таймаутов на время коннекта и время чтения, позволила отфильтровать сайты с "плохим" соединением. Это подняло пропускную способность на 40%: 223 url/min против 173 url/min до задания таймаутов.